### PR TITLE
Add an argument to load custom defined models

### DIFF
--- a/src/model_wrapper.py
+++ b/src/model_wrapper.py
@@ -44,15 +44,15 @@ class Model_Wrapper(object):
         self.tokenizer.save_pretrained(path)
         
 
-    def load_model(self, path, max_length=25, use_cuda=True, lowercase=True):
-        self.load_bert(path, max_length, use_cuda)
+    def load_model(self, path, max_length=25, use_cuda=True, lowercase=True, trust_remote_code=False):
+        self.load_bert(path, max_length, use_cuda, trust_remote_code=trust_remote_code)
         
         return self
 
-    def load_bert(self, path, max_length, use_cuda, lowercase=True):
+    def load_bert(self, path, max_length, use_cuda, lowercase=True, trust_remote_code=False):
         self.tokenizer = AutoTokenizer.from_pretrained(path, 
                 use_fast=True, do_lower_case=lowercase)
-        self.encoder = AutoModel.from_pretrained(path)
+        self.encoder = AutoModel.from_pretrained(path, trust_remote_code=trust_remote_code)
         if use_cuda:
             self.encoder = self.encoder.cuda()
 

--- a/train/train.py
+++ b/train/train.py
@@ -85,6 +85,8 @@ def parse_args():
     parser.add_argument('--miner_margin', default=0.2, type=float) 
     parser.add_argument('--type_of_triplets', default="all", type=str) 
     parser.add_argument('--agg_mode', default="cls", type=str, help="{cls|mean|mean_all_tok}") 
+    parser.add_argument('--trust_remote_code', action="store_true",
+                        help="allow for custom models defined in their own modeling files")
 
     args = parser.parse_args()
     return args
@@ -231,6 +233,7 @@ def main(args):
         path=args.model_dir,
         max_length=args.max_length,
         use_cuda=args.use_cuda,
+        trust_remote_code=args.trust_remote_code,
         #lowercase=not args.cased
     )
     


### PR DESCRIPTION
Hello,

Thank you for your useful papers and code.

I had to do a small practical modification that I propose to share. 
The goal is to allow loading a custom model defined in a modeling file.
The modification is that AutoModel.load_pretrained() is called with trust_remote_code=True if an optional --trust_remote_code argument is passed to train.py.

Regards,

Alexandre Englebert